### PR TITLE
Pretty-print fix for EOWEB pages

### DIFF
--- a/rss-xls-to-xml-translator.py
+++ b/rss-xls-to-xml-translator.py
@@ -719,7 +719,7 @@ if __name__ == '__main__':
         #             nfiledata = nfiledata.replace(maintag, newmaintag)
         # Pretty print xml output
         if args.p:
-            xml = xml.dom.minidom.parseString(nfiledata.replace("\n",""))
+            xml = xml.dom.minidom.parseString(nfiledata.replace("\n"," "))
             nfiledata = xml.toprettyxml()
             # bs = BeautifulSoup(nfiledata, 'xml')
             # nfiledata = bs.prettify()


### PR DESCRIPTION
According to people involved in EOWEB activities, there is currently a problem with multi-line text in the output XMLs. Apparently EOWEB pages do not recognise "\n" as a newline and simply ignore it, and as a result they sometimes get text unintentionally concatenated where it shouldn't be.

The current "pretty print" functionality of the script (-p flag) simply removes all "\n" occurrences from the output XML. A proposed fix for the above is to instead replace all "\n" with spaces. This has been tested before and the results were acceptable for the EOWEB team.